### PR TITLE
Update regex to support TB values

### DIFF
--- a/content.js
+++ b/content.js
@@ -32,7 +32,7 @@ if (!window.bqCostObserverInitiated) {
     }
 
     function processAndUpdateText(node) {
-        const regex = /This query will process ([\d.,]+) ([KBGM]B) when run\./;
+        const regex = /This query will process ([\d.,]+) ([KBGMT]B) when run\./;
         const match = node.nodeValue.match(regex);
         if (match) {
             const size = parseFloat(match[1].replace(',', ''));


### PR DESCRIPTION
This PR updates the regex which matches the estimated query size on the page to support TB values. Large queries were not being correctly matched and estimated without it.